### PR TITLE
fix: use correct package exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 dist
 .prettierignore
+.idea/

--- a/package.json
+++ b/package.json
@@ -20,18 +20,17 @@
     "vue"
   ],
   "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
     "./client": {
       "types": "./client.d.ts"
     },
-    "./*": "./*",
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
-    }
+    "./*": "./*"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
     "client.d.ts",


### PR DESCRIPTION
You should remove CJS support:
```json
"exports": {
    ".": "./dist/index.js",
    "./client": {
      "types": "./client.d.ts"
    },
    "./*": "./*"
  },
```

and

```json
"build": "tsup src/index.ts --dts --format esm",
```

closes #7

![image](https://github.com/user-attachments/assets/9abee6c4-2280-4c5d-8ae7-cd49d0456c7a)
