### PR TITLE
Fix npm bugs metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git+https://github.com/loicduong/vite-plugin-vue-layouts-next.git"
   },
-  "bugs": "https://github.com/loicduong/vite-plugin-vue-layouts-next",
+  "bugs": "https://github.com/loicduong/vite-plugin-vue-layouts-next/issues",
   "keywords": [
     "typescript",
     "vite-plugin",


### PR DESCRIPTION
This updates the package metadata so npm points bug reports straight to the GitHub issues page instead of the repo root.

Checks run:
- node -e "const p=require('./package.json'); if(p.bugs !== 'https://github.com/loicduong/vite-plugin-vue-layouts-next/issues') process.exit(1); console.log(p.bugs)"
- npm pack --dry-run --ignore-scripts --json
- git diff --check